### PR TITLE
mixitupのurlからschemaを抜いてみた

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
   </footer>
 
   <script src="jquery-3.1.1.min.js"></script>
-  <script src="http://cdn.jsdelivr.net/jquery.mixitup/latest/jquery.mixitup.min.js"></script>
+  <script src="//cdn.jsdelivr.net/jquery.mixitup/latest/jquery.mixitup.min.js"></script>
   <script>
     $(function(){
     $('#Container').mixItUp();


### PR DESCRIPTION
ご査収ください。

https://github.com/theoldmoon0602/chige12.github.io/blob/theoldmoon0602-patch-1/index.html

https://developer.mozilla.org/ja/docs/Security/%E6%B7%B7%E5%9C%A8%E3%82%B3%E3%83%B3%E3%83%86%E3%83%B3%E3%83%84 にあるようにhttpsのページなのにcdnがhttpなのが悪いのかなーと思ったのでhttp:を抜いて//から始まるurlにしてみました